### PR TITLE
chore: reset fork build dist base branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,16 +3,31 @@ on:
     branches:
       - main
 name: build and release-please
+env:
+        ACTION_NAME: deploy-cloud-functions
 jobs:
+  update-fork:
+      runs-on: ubuntu-latest
+      steps:
+        - name: sync fork
+          uses: actions/checkout@v2
+          with:
+            repository: google-github-actions-bot/${{env.ACTION_NAME}}
+            token: ${{ secrets.ACTIONS_BOT_TOKEN }}
+        - run: |-
+            git remote add upstream https://github.com/${GITHUB_REPOSITORY}
+            git fetch upstream
+            git checkout main
+            git reset --hard upstream/main 
+            git rebase upstream/main
+            git push origin main -f
   build:
-    env:
-      ACTION_NAME: deploy-cloud-functions
+    needs: [update-fork]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: git pull
       - name: install
         run: npm install
       - name: build


### PR DESCRIPTION
I noticed a bug was not triggering the latest dist build PRs, it turns out that the base branch of the fork where the dist is being committed needs to be kept upto date with the current main for the action to work as expected.

This PR introduces an `update-fork` job that always keeps the fork at the same commit as upstream by reseting it to upstream/main before building and committing dist followed by opening PR. 