### PR TITLE
chore: skip test fork, add label

### DIFF
--- a/.github/workflows/deploy-cf-it.yml
+++ b/.github/workflows/deploy-cf-it.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   gcloud:
+    if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
     name: with setup-gcloud
     runs-on: ubuntu-latest
     steps:
@@ -40,6 +41,7 @@ jobs:
         CF_NAME: projects/${{ secrets.DEPLOY_CF_PROJECT_ID }}/locations/us-central1/functions/cf-http-gcloud-${{ github.run_number }}
 
   b64_json:
+    if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
     name: with base64 json creds
     runs-on: ubuntu-latest
     steps:
@@ -77,6 +79,7 @@ jobs:
         CF_NAME: projects/${{ secrets.DEPLOY_CF_PROJECT_ID }}/locations/us-central1/functions/cf-http-b64-${{ github.run_number }}
 
   json:
+    if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
     name: with json creds
     runs-on: ubuntu-latest
     steps:
@@ -116,6 +119,7 @@ jobs:
         CF_REGION: us-east1
 
   json-event-trigger:
+    if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
     name: test event trigger
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,17 @@
+on: pull_request_target
+
+jobs:
+  apply-label:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Fork']
+            })

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,9 +66,8 @@ jobs:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           release-type: node
           fork: true
+          bump-minor-pre-major: true
           package-name: ${{env.ACTION_NAME}}
-          path: ${{env.ACTION_NAME}}
-          monorepo-tags: ${{env.ACTION_NAME}}
           command: release-pr
   release-please-release:
     runs-on: ubuntu-latest
@@ -79,6 +78,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
           package-name: ${{env.ACTION_NAME}}
-          path: ${{env.ACTION_NAME}}
-          monorepo-tags: ${{env.ACTION_NAME}}
+          bump-minor-pre-major: true
           command: github-release

--- a/tests/cloudFunctionClient.test.ts
+++ b/tests/cloudFunctionClient.test.ts
@@ -29,6 +29,12 @@ describe('CloudFunction', function () {
   });
 
   it('initializes with ADC', async function () {
+    if (
+      !process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+      !process.env.GCLOUD_PROJECT
+    ) {
+      this.skip();
+    }
     const client = new CloudFunctionClient(region);
     expect(client.auth.jsonContent).eql(null);
     const auth = (await client.getAuthClient()) as JWT;


### PR DESCRIPTION
- fixes ADC test to skip if required env vars are not found
- skip running int test on forks 
- explicitly label forks, example: https://github.com/bharathkkb/upload-cloud-storage/pulls
- remove older monorepo configs for release-please