### PR TITLE
feat: add env var file support

### DIFF
--- a/.github/workflows/deploy-cf-it.yml
+++ b/.github/workflows/deploy-cf-it.yml
@@ -140,6 +140,7 @@ jobs:
         credentials: ${{ secrets.DEPLOY_CF_SA_KEY_JSON }}
         event_trigger_type: providers/cloud.pubsub/eventTypes/topic.publish
         event_trigger_resource: ${{ secrets.DEPLOY_CF_EVENT_PUBSUB_TOPIC }}
+        env_vars_file: './tests/env-var-files/test.good.yaml'
     - uses: actions/setup-node@master
       with:
         node-version: 12.x

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ steps:
   KEY1=VALUE1,KEY2=VALUE2. All existing environment variables will be
   removed first.
 
+- `env_vars_file`: (Optional) Path to a local YAML file with definitions for all environment variables. Only one of env_vars or env_vars_file can be specified.
+
 - `source_dir`: (Optional) Source directory for the function. Defaults to current directory.
 
 - `project_id`: (Optional) ID of the Google Cloud project. If provided, this

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ steps:
   KEY1=VALUE1,KEY2=VALUE2. All existing environment variables will be
   removed first.
 
-- `env_vars_file`: (Optional) Path to a local YAML file with definitions for all environment variables. Only one of env_vars or env_vars_file can be specified.
+- `env_vars_file`: (Optional) Path to a local YAML file with definitions for all environment variables. An example env_vars_file can be found [here](tests/env-var-files/test.good.yaml). Only one of env_vars or env_vars_file can be specified.
 
 - `source_dir`: (Optional) Source directory for the function. Defaults to current directory.
 

--- a/action.yaml
+++ b/action.yaml
@@ -53,7 +53,12 @@ inputs:
 
   env_vars:
     description: |-
-      List of key-value pairs to set as environment variables in the form KEY1=VALUE1,KEY2=VALUE2.
+      List of key-value pairs to set as environment variables in the form KEY1=VALUE1,KEY2=VALUE2. Only one of env_vars or env_vars_file can be specified.
+    required: false
+  
+  env_vars_file:
+    description: |-
+      Path to a local YAML file with definitions for all environment variables. Only one of env_vars or env_vars_file can be specified.
     required: false
 
   entry_point:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2343,6 +2343,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+    },
     "yargs": {
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "archiver": "^5.0.0",
     "fs": "0.0.1-security",
     "gaxios": "^3.1.0",
+    "google-auth-library": "^6.0.6",
     "googleapis": "^58.0.0",
-    "google-auth-library": "^6.0.6"
+    "yaml": "^1.10.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",

--- a/src/cloudFunction.ts
+++ b/src/cloudFunction.ts
@@ -128,7 +128,6 @@ export class CloudFunction {
       envVars = this.parseEnvVarsFile(opts.envVarsFile);
       request.environmentVariables = envVars;
     }
-    console.log(envVars);
 
     this.request = request;
     this.name = opts.name;

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ async function run(): Promise<void> {
     const availableMemoryMb = core.getInput('memory_mb');
     const region = core.getInput('region') || 'us-central1';
     const envVars = core.getInput('env_vars');
+    const envVarsFile = core.getInput('env_vars_file');
     const entryPoint = core.getInput('entry_point');
     const sourceDir = core.getInput('source_dir');
     const vpcConnector = core.getInput('vpc_connector');
@@ -50,6 +51,7 @@ async function run(): Promise<void> {
       availableMemoryMb: +availableMemoryMb,
       entryPoint,
       envVars,
+      envVarsFile,
       timeout,
       maxInstances: +maxInstances,
       eventTriggerType,

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -78,6 +78,40 @@ describe('CloudFunction', function () {
     );
   });
 
+  it('creates a http function with envVarsFile', function () {
+    const envVarsFile = 'tests/env-var-files/test.good.yaml';
+    const cf = new CloudFunction({ name, runtime, parent, envVarsFile });
+    expect(cf.request.name).equal(`${parent}/functions/${name}`);
+    expect(cf.request.environmentVariables?.KEY1).equal('VALUE1');
+    expect(cf.request.environmentVariables?.KEY2).equal('VALUE2');
+  });
+
+  it('throws an error with bad envVarsFile', function () {
+    const envVarsFile = 'tests/env-var-files/test.bad.yaml';
+    expect(function () {
+      new CloudFunction({ name, runtime, parent, envVarsFile });
+    }).to.throw(
+      'env_vars_file yaml must contain only key/value pair of strings. Error parsing key KEY2 of type string with value VALUE2,VALUE3 of type object',
+    );
+  });
+
+  it('throws an error with nonexistent envVarsFile', function () {
+    const envVarsFile = 'tests/env-var-files/test.nonexistent.yaml';
+    expect(function () {
+      new CloudFunction({ name, runtime, parent, envVarsFile });
+    }).to.throw(
+      "ENOENT: no such file or directory, open 'tests/env-var-files/test.nonexistent.yaml",
+    );
+  });
+
+  it('throws an error with both envVarsFile and envVars specified', function () {
+    const envVarsFile = 'tests/env-var-files/test.good.yaml';
+    const envVars = 'KEY1=VALUE1,KEY2=VALUE2';
+    expect(function () {
+      new CloudFunction({ name, runtime, parent, envVarsFile, envVars });
+    }).to.throw('Only one of env_vars or env_vars_file can be specified.');
+  });
+
   it('creates an event function', function () {
     const eventTriggerType = 'fooType';
     const eventTriggerResource = 'barResource';

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -84,6 +84,7 @@ describe('CloudFunction', function () {
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.environmentVariables?.KEY1).equal('VALUE1');
     expect(cf.request.environmentVariables?.KEY2).equal('VALUE2');
+    expect(cf.request.environmentVariables?.JSONKEY).equal('{"bar":"baz"}');
   });
 
   it('throws an error with bad envVarsFile', function () {

--- a/tests/cloudFunctionClient.test.ts
+++ b/tests/cloudFunctionClient.test.ts
@@ -167,6 +167,9 @@ describe('CloudFunction', function () {
     // expect to have the correct env vars from env var file
     expect(result.response?.environmentVariables.KEY1).to.eq('VALUE1');
     expect(result.response?.environmentVariables.KEY2).to.eq('VALUE2');
+    expect(result.response?.environmentVariables.JSONKEY).to.eq(
+      '{"bar":"baz"}',
+    );
     // expect function to be deleted without error
     const deleteFunc = await client.delete(newHttpFunc.functionPath);
     expect(deleteFunc.done).to.eq(true);

--- a/tests/env-var-files/test.bad.yaml
+++ b/tests/env-var-files/test.bad.yaml
@@ -1,0 +1,4 @@
+ KEY1: VALUE1
+ KEY2:
+  - VALUE2
+  - VALUE3

--- a/tests/env-var-files/test.good.yaml
+++ b/tests/env-var-files/test.good.yaml
@@ -1,0 +1,3 @@
+ KEY1: VALUE1
+ KEY2: VALUE2
+ 

--- a/tests/env-var-files/test.good.yaml
+++ b/tests/env-var-files/test.good.yaml
@@ -1,3 +1,4 @@
  KEY1: VALUE1
  KEY2: VALUE2
+ JSONKEY: '{"bar":"baz"}'
  


### PR DESCRIPTION
Adds support for an env var yaml file input similar to [gcloud cli ](https://cloud.google.com/sdk/gcloud/reference/functions/deploy#--env-vars-file)
fixes #32 #17 