### PR TITLE
Increase deploy create/update timeout

### DIFF
--- a/src/cloudFunctionClient.ts
+++ b/src/cloudFunctionClient.ts
@@ -238,6 +238,8 @@ export class CloudFunctionClient {
       const awaitUpdate = await this.pollOperation(
         updateFunctionResponse.data,
         'Updating function deployment',
+        2,
+        150,
       );
       core.info('Function deployment updated');
       return awaitUpdate;
@@ -255,6 +257,8 @@ export class CloudFunctionClient {
       const awaitCreate = await this.pollOperation(
         createFunctionResponse.data,
         'Creating function deployment',
+        2,
+        150,
       );
       core.info('Function deployment created');
       return awaitCreate;


### PR DESCRIPTION
Right now the timeout is nominally 200 seconds, and my deployments often flakily fail. The deployments in GCP succeed, but the GitHub action stops listening and fails. This increases the timeout to nominally 300 seconds.

Resolves issue #45.