### PR TITLE
Corrrect authorization notes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ with the following roles:
 
 This service account needs to be a member of the `App Engine default service account`
 `(PROJECT_ID@appspot.gserviceaccount.com)`, with role
-`Service Account User` (`roles/iam.serviceAccountUser`). See [Additional configuration for deployment](https://cloud.google.com/functions/docs/reference/iam/roles#additional-configuration) 
-for additional instructions.
+`Service Account User` (`roles/iam.serviceAccountUser`). See [additional configuration for deployment](https://cloud.google.com/functions/docs/reference/iam/roles#additional-configuration) 
+for further instructions.
 
 ### Used with `setup-gcloud`
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ with the following roles:
   - Can create, update, and delete functions.
   - Can set IAM policies and view source code.
 
-This service account needs to a member of the `Compute Engine default service account`,
-`(PROJECT_NUMBER-compute@developer.gserviceaccount.com)`, with role
-`Service Account User`. To grant a user permissions for a service account, use
-one of the methods found in [Configuring Ownership and access to a service account](https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_user_for_a_service_account).
+This service account needs to be a member of the `App Engine default service account`
+`(PROJECT_ID@appspot.gserviceaccount.com)`, with role
+`Service Account User` (`roles/iam.serviceAccountUser`). See [Additional configuration for deployment](https://cloud.google.com/functions/docs/reference/iam/roles#additional-configuration) 
+for step-by-step instructions if you don't know how.
 
 ### Used with `setup-gcloud`
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ with the following roles:
 This service account needs to be a member of the `App Engine default service account`
 `(PROJECT_ID@appspot.gserviceaccount.com)`, with role
 `Service Account User` (`roles/iam.serviceAccountUser`). See [Additional configuration for deployment](https://cloud.google.com/functions/docs/reference/iam/roles#additional-configuration) 
-for step-by-step instructions if you don't know how.
+for additional instructions.
 
 ### Used with `setup-gcloud`
 


### PR DESCRIPTION
The service account needs to be member of App Engine default account, per troubleshooting and docs:
https://cloud.google.com/functions/docs/troubleshooting#role-actAs
https://cloud.google.com/functions/docs/reference/iam/roles#additional-configuration
https://cloud.google.com/functions/docs/concepts/iam#runtime_service_accounts