### PR TITLE
feat: add function labels support

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ inputs:
       formatted private key which can be exported from the Cloud Console. The
       value can be raw or base64-encoded.
     required: false
-    
+
   name:
     description: |-
       Name of the Cloud Function.
@@ -55,15 +55,20 @@ inputs:
     description: |-
       List of key-value pairs to set as environment variables in the form KEY1=VALUE1,KEY2=VALUE2. Only one of env_vars or env_vars_file can be specified.
     required: false
-  
+
   env_vars_file:
     description: |-
       Path to a local YAML file with definitions for all environment variables. Only one of env_vars or env_vars_file can be specified.
     required: false
 
+  labels:
+    description: |-
+      List of key-value pairs to set as function labels in the form label1=VALUE1,label2=VALUE2.
+    required: false
+
   entry_point:
     description: |-
-      Name of a function (as defined in source code) that will be executed. Defaults to the resource name suffix, if not specified. 
+      Name of a function (as defined in source code) that will be executed. Defaults to the resource name suffix, if not specified.
     required: false
 
   runtime:

--- a/src/cloudFunction.ts
+++ b/src/cloudFunction.ts
@@ -40,6 +40,7 @@ export type EnvVar = {
  * @param eventTriggerType Specifies which action should trigger the function.
  * @param eventTriggerResource Specifies which resource from eventTrigger is observed.
  * @param eventTriggerService The hostname of the service that should be observed.
+ * @param labels List of key-value pairs to set as function labels.
  */
 
 export type CloudFunctionOptions = {
@@ -59,6 +60,7 @@ export type CloudFunctionOptions = {
   eventTriggerType?: string;
   eventTriggerResource?: string;
   eventTriggerService?: string;
+  labels?: string;
 };
 
 /**
@@ -129,6 +131,10 @@ export class CloudFunction {
       request.environmentVariables = envVars;
     }
 
+    if (opts?.labels) {
+      request.labels = this.parseEnvVars(opts.labels);
+    }
+
     this.request = request;
     this.name = opts.name;
     this.sourceDir = opts.sourceDir ? opts.sourceDir : './';
@@ -155,7 +161,7 @@ export class CloudFunction {
     envVarList.forEach((envVar) => {
       if (!envVar.includes('=')) {
         throw new TypeError(
-          `Env Vars must be in "KEY1=VALUE1,KEY2=VALUE2" format, received ${envVar}`,
+          `Env Vars and/or Labels must be in "KEY1=VALUE1,KEY2=VALUE2" format, received ${envVar}`,
         );
       }
       const keyValue = envVar.split('=');

--- a/src/cloudFunction.ts
+++ b/src/cloudFunction.ts
@@ -18,7 +18,7 @@ import { cloudfunctions_v1 } from 'googleapis';
 import fs from 'fs';
 import YAML from 'yaml';
 
-export type EnvVar = {
+export type KVPair = {
   [key: string]: string;
 };
 
@@ -123,7 +123,7 @@ export class CloudFunction {
     // Parse env vars
     let envVars;
     if (opts?.envVars) {
-      envVars = this.parseEnvVars(opts.envVars);
+      envVars = this.parseKVPairs(opts.envVars);
       request.environmentVariables = envVars;
     }
     if (opts?.envVarsFile) {
@@ -132,7 +132,7 @@ export class CloudFunction {
     }
 
     if (opts?.labels) {
-      request.labels = this.parseEnvVars(opts.labels);
+      request.labels = this.parseKVPairs(opts.labels);
     }
 
     this.request = request;
@@ -150,24 +150,24 @@ export class CloudFunction {
   }
 
   /**
-   * Parses a string of the format `KEY1=VALUE1`.
+   * Parses a string of the format `KEY1=VALUE1,KEY2=VALUE2`.
    *
-   * @param envVarInput Env var string to parse.
+   * @param values String with key/value pairs to parse.
    * @returns map of type {KEY1:VALUE1}
    */
-  protected parseEnvVars(envVarInput: string): EnvVar {
-    const envVarList = envVarInput.split(',');
-    const envVars: EnvVar = {};
-    envVarList.forEach((envVar) => {
-      if (!envVar.includes('=')) {
+  protected parseKVPairs(values: string): KVPair {
+    const valuePairs = values.split(',');
+    const kvPairs: KVPair = {};
+    valuePairs.forEach((pair) => {
+      if (!pair.includes('=')) {
         throw new TypeError(
-          `Env Vars and/or Labels must be in "KEY1=VALUE1,KEY2=VALUE2" format, received ${envVar}`,
+          `The expected data format should be "KEY1=VALUE1", got "${pair}" while parsing "${values}"`,
         );
       }
-      const keyValue = envVar.split('=');
-      envVars[keyValue[0]] = keyValue[1];
+      const keyValue = pair.split('=');
+      kvPairs[keyValue[0]] = keyValue[1];
     });
-    return envVars;
+    return kvPairs;
   }
 
   /**
@@ -176,9 +176,9 @@ export class CloudFunction {
    * @param envVarsFile env var file path.
    * @returns map of type {KEY1:VALUE1}
    */
-  protected parseEnvVarsFile(envVarFilePath: string): EnvVar {
+  protected parseEnvVarsFile(envVarFilePath: string): KVPair {
     const content = fs.readFileSync(envVarFilePath, 'utf-8');
-    const yamlContent = YAML.parse(content) as EnvVar;
+    const yamlContent = YAML.parse(content) as KVPair;
     for (const [key, val] of Object.entries(yamlContent)) {
       if (typeof key !== 'string' || typeof val !== 'string') {
         throw new Error(

--- a/src/cloudFunctionClient.ts
+++ b/src/cloudFunctionClient.ts
@@ -238,6 +238,7 @@ export class CloudFunctionClient {
         'eventTrigger.eventType',
         'eventTrigger.resource',
         'eventTrigger.service',
+        'labels',
       ];
       const updateFunctionRequest: cloudfunctions_v1.Params$Resource$Projects$Locations$Functions$Patch = {
         updateMask: updateMasks.join(','),

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ async function run(): Promise<void> {
     const eventTriggerType = core.getInput('event_trigger_type');
     const eventTriggerResource = core.getInput('event_trigger_resource');
     const eventTriggerService = core.getInput('event_trigger_service');
+    const labels = core.getInput('labels');
 
     // Create Cloud Functions client
     const client = new CloudFunctionClient(region, { projectId, credentials });
@@ -59,6 +60,7 @@ async function run(): Promise<void> {
       eventTriggerService,
       vpcConnector,
       serviceAccountEmail,
+      labels,
     });
 
     // Deploy function

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -96,7 +96,16 @@ describe('CloudFunction', function () {
     expect(function () {
       new CloudFunction({ name, runtime, parent, envVars });
     }).to.throw(
-      'Env Vars and/or Labels must be in "KEY1=VALUE1,KEY2=VALUE2" format, received KEY1',
+      'The expected data format should be "KEY1=VALUE1", got "KEY1" while parsing "KEY1,VALUE1"',
+    );
+  });
+
+  it('throws an error with bad labels', function () {
+    const envVars = 'label1=value1,label2';
+    expect(function () {
+      new CloudFunction({ name, runtime, parent, envVars });
+    }).to.throw(
+      'The expected data format should be "KEY1=VALUE1", got "label2" while parsing "label1=value1,label2"',
     );
   });
 

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -25,8 +25,28 @@ describe('CloudFunction', function () {
     expect(cf.request.environmentVariables?.KEY1).equal('VALUE1');
   });
 
+  it('creates an http function with one label', function () {
+    const labels = 'label1=value1';
+    const cf = new CloudFunction({ name, runtime, parent, labels });
+    expect(cf.request.name).equal(`${parent}/functions/${name}`);
+    expect(cf.request.runtime).equal(runtime);
+    expect(cf.request.httpsTrigger).not.to.be.null;
+    expect(cf.request.labels?.label1).equal('value1');
+  });
+
+  it('creates an http function with two labels', function () {
+    const labels = 'label1=value1,label2=value2';
+    const cf = new CloudFunction({ name, runtime, parent, labels });
+    expect(cf.request.name).equal(`${parent}/functions/${name}`);
+    expect(cf.request.runtime).equal(runtime);
+    expect(cf.request.httpsTrigger).not.to.be.null;
+    expect(cf.request.labels?.label1).equal('value1');
+    expect(cf.request.labels?.label2).equal('value2');
+  });
+
   it('creates a http function with optionals', function () {
     const envVars = 'KEY1=VALUE1';
+    const labels = 'label1=value1';
     const funcOptions = {
       name: name,
       description: 'foo',
@@ -40,6 +60,7 @@ describe('CloudFunction', function () {
       timeout: '500',
       maxInstances: 10,
       availableMemoryMb: 512,
+      labels: labels,
     };
     const cf = new CloudFunction(funcOptions);
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
@@ -56,6 +77,7 @@ describe('CloudFunction', function () {
     expect(cf.request.availableMemoryMb).equal(funcOptions.availableMemoryMb);
     expect(cf.request.httpsTrigger).not.to.be.null;
     expect(cf.request.environmentVariables?.KEY1).equal('VALUE1');
+    expect(cf.request.labels?.label1).equal('value1');
   });
 
   it('creates a http function with three envVars', function () {
@@ -74,7 +96,7 @@ describe('CloudFunction', function () {
     expect(function () {
       new CloudFunction({ name, runtime, parent, envVars });
     }).to.throw(
-      'Env Vars must be in "KEY1=VALUE1,KEY2=VALUE2" format, received KEY1',
+      'Env Vars and/or Labels must be in "KEY1=VALUE1,KEY2=VALUE2" format, received KEY1',
     );
   });
 


### PR DESCRIPTION
Adds a new parameter for the action - `labels`. Can be something like
```
      - uses: google-github-actions/deploy-cloud-functions@main
        with:
          name: function-demo
          runtime: node12
          entry_point: hello_world
          memory_mb: 128
          labels: env=demo,version=${{ github.sha }}
```
Works almost the same way as Env variables. But sets `"labels": { string: string, ... },` part of the `CloudFunction` object.