### PR TITLE
fix: improve env var parsing behaviour (#122)

### DIFF
--- a/src/cloudFunction.ts
+++ b/src/cloudFunction.ts
@@ -164,8 +164,10 @@ export class CloudFunction {
           `The expected data format should be "KEY1=VALUE1", got "${pair}" while parsing "${values}"`,
         );
       }
-      const keyValue = pair.split('=');
-      kvPairs[keyValue[0]] = keyValue[1];
+      // Split on the first delimiter only
+      const name = pair.substring(0, pair.indexOf('='));
+      const value = pair.substring(pair.indexOf('=') + 1);
+      kvPairs[name] = value;
     });
     return kvPairs;
   }

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -109,6 +109,16 @@ describe('CloudFunction', function () {
     );
   });
 
+  it('creates a http function with two envVars containing equals character', function () {
+    const envVars = 'KEY1=VALUE=1,KEY2=VALUE=2';
+    const cf = new CloudFunction({ name, runtime, parent, envVars });
+    expect(cf.request.name).equal(`${parent}/functions/${name}`);
+    expect(cf.request.runtime).equal(runtime);
+    expect(cf.request.httpsTrigger).not.to.be.null;
+    expect(cf.request.environmentVariables?.KEY1).equal('VALUE=1');
+    expect(cf.request.environmentVariables?.KEY2).equal('VALUE=2');
+  });
+
   it('creates a http function with envVarsFile', function () {
     const envVarsFile = 'tests/env-var-files/test.good.yaml';
     const cf = new CloudFunction({ name, runtime, parent, envVarsFile });


### PR DESCRIPTION
* fix(envVars): Handle multiple delimiters when parsing

Split a key/val pair only on the first equals character, preserving
any remaining equals characters in the key and value.

* test(envVars): Test env var string parsing with multiple delim chars