### PR TITLE
feat: custom delimiters for environment variables

### DIFF
--- a/src/cloudFunction.ts
+++ b/src/cloudFunction.ts
@@ -48,6 +48,7 @@ export type CloudFunctionOptions = {
   sourceDir?: string;
   envVars?: string;
   envVarsFile?: string;
+  envVarsDelimiter?: string;
   entryPoint?: string;
   runtime: string;
   availableMemoryMb?: number;
@@ -123,11 +124,16 @@ export class CloudFunction {
       ? opts.availableMemoryMb
       : null;
 
+    let envVarsDelimiter = ','; // Default delimiter is `,`
+
     // Check if `envVars` or `envVarsFile` are set.
     // If two var keys are the same between `envVars` and `envVarsFile`
     // `envVars` will override the one on `envVarsFile`
     if (opts?.envVars || opts?.envVarsFile) {
       let envVars;
+      if (opts?.envVarsDelimiter) {
+        envVarsDelimiter = opts.envVarsDelimiter;
+      }
 
       if (opts?.envVarsFile) {
         envVars = parseEnvVarsFile(opts.envVarsFile);
@@ -136,14 +142,14 @@ export class CloudFunction {
       if (opts?.envVars) {
         envVars = {
           ...envVars,
-          ...parseKVPairs(opts.envVars),
+          ...parseKVPairs(opts.envVars, envVarsDelimiter),
         };
       }
       request.environmentVariables = envVars;
     }
 
     if (opts?.labels) {
-      request.labels = parseKVPairs(opts.labels);
+      request.labels = parseKVPairs(opts.labels, envVarsDelimiter);
     }
 
     this.request = request;

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ async function run(): Promise<void> {
     const region = core.getInput('region') || 'us-central1';
     const envVars = core.getInput('env_vars');
     const envVarsFile = core.getInput('env_vars_file');
+    const envVarsDelimiter = core.getInput('env_vars_delimiter');
     const entryPoint = core.getInput('entry_point');
     const sourceDir = core.getInput('source_dir');
     const vpcConnector = core.getInput('vpc_connector');
@@ -58,6 +59,7 @@ async function run(): Promise<void> {
       entryPoint,
       envVars,
       envVarsFile,
+      envVarsDelimiter,
       timeout,
       maxInstances: +maxInstances,
       eventTriggerType,

--- a/src/util.ts
+++ b/src/util.ts
@@ -150,27 +150,14 @@ export async function uploadSource(
 }
 
 /**
- * Parses a string of the format `KEY1=VALUE1,KEY2=VALUE2`.
+ * Parses a string of the format `KEY1=VALUE1<delimiter>KEY2=VALUE2`.
  *
  * @param values String with key/value pairs to parse.
+ * @param delimiter String on which to split the values.
  * @returns map of type {KEY1:VALUE1}
  */
-export function parseKVPairs(values: string): KVPair {
-  /**
-   * Regex to split on ',' while ignoring commas in double quotes
-   * /,             // Match a `,`
-   *   (?=          // Positive lookahead after the `,`
-   *      (?:       // Not capturing group since we don't actually want to extract the values
-   *        [^\"]*  // Any number of non `"` characters
-   *        \"      // Match a `"`
-   *        [^\"]   // Any number of non `"` characters
-   *        *\"     // Match a `"`
-   *      )*        // Capture as many times as needed
-   *      [^\"]     // End with any number of non `"` characters
-   *   *$)          // Ensure we are at the end of the line
-   * /g             // Match all
-   */
-  const valuePairs = values.split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/g);
+export function parseKVPairs(values: string, delimiter: string): KVPair {
+  const valuePairs = values.split(delimiter).filter(x => x !== "");
   const kvPairs: KVPair = {};
   valuePairs.forEach((pair) => {
     if (!pair.includes('=')) {
@@ -181,10 +168,6 @@ export function parseKVPairs(values: string): KVPair {
     // Split on the first delimiter only
     const name = pair.substring(0, pair.indexOf('='));
     let value = pair.substring(pair.indexOf('=') + 1);
-    if (value.match(/".*"/)) {
-      // If our value includes quotes (Ex. '"foo"'), we should ignore the outer quotes
-      value = value.slice(1, -1);
-    }
     kvPairs[name] = value;
   });
   return kvPairs;

--- a/src/util.ts
+++ b/src/util.ts
@@ -157,7 +157,7 @@ export async function uploadSource(
  * @returns map of type {KEY1:VALUE1}
  */
 export function parseKVPairs(values: string, delimiter: string): KVPair {
-  const valuePairs = values.split(delimiter).filter(x => x !== "");
+  const valuePairs = values.split(delimiter).filter((x) => x !== '');
   const kvPairs: KVPair = {};
   valuePairs.forEach((pair) => {
     if (!pair.includes('=')) {
@@ -167,7 +167,7 @@ export function parseKVPairs(values: string, delimiter: string): KVPair {
     }
     // Split on the first delimiter only
     const name = pair.substring(0, pair.indexOf('='));
-    let value = pair.substring(pair.indexOf('=') + 1);
+    const value = pair.substring(pair.indexOf('=') + 1);
     kvPairs[name] = value;
   });
   return kvPairs;

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -97,13 +97,14 @@ describe('CloudFunction', function () {
     expect(cf.request.environmentVariables?.KEY3).equal('VALUE3');
   });
 
-  it('creates a http function with quoted envVars', function () {
-    const envVars = 'KEY1="VALUE1.1,VALUE1.2",KEY2=VALUE2,KEY3=VALUE3';
+  it('creates a http function with some quoted and some unquoted envVars', function () {
+    const obj = {foo: "bar", baz: "foo"};
+    const envVars = `KEY1="${JSON.stringify(obj)}",KEY2=VALUE2,KEY3=VALUE3`;
     const cf = new CloudFunction({ name, runtime, parent, envVars });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
-    expect(cf.request.environmentVariables?.KEY1).equal('VALUE1.1,VALUE1.2');
+    expect(JSON.parse(cf.request.environmentVariables?.KEY1 || "{}")).deep.equals(obj);
     expect(cf.request.environmentVariables?.KEY2).equal('VALUE2');
     expect(cf.request.environmentVariables?.KEY3).equal('VALUE3');
   });

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -98,13 +98,15 @@ describe('CloudFunction', function () {
   });
 
   it('creates a http function with some quoted and some unquoted envVars', function () {
-    const obj = {foo: "bar", baz: "foo"};
+    const obj = { foo: 'bar', baz: 'foo' };
     const envVars = `KEY1="${JSON.stringify(obj)}",KEY2=VALUE2,KEY3=VALUE3`;
     const cf = new CloudFunction({ name, runtime, parent, envVars });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
-    expect(JSON.parse(cf.request.environmentVariables?.KEY1 || "{}")).deep.equals(obj);
+    expect(
+      JSON.parse(cf.request.environmentVariables?.KEY1 || '{}'),
+    ).deep.equals(obj);
     expect(cf.request.environmentVariables?.KEY2).equal('VALUE2');
     expect(cf.request.environmentVariables?.KEY3).equal('VALUE3');
   });
@@ -124,43 +126,6 @@ describe('CloudFunction', function () {
       new CloudFunction({ name, runtime, parent, envVars });
     }).to.throw(
       'The expected data format should be "KEY1=VALUE1", got "label2" while parsing "label1=value1,label2"',
-    );
-  });
-
-  it('creates a http function with two envVars containing equals character', function () {
-    const envVars = 'KEY1=VALUE=1,KEY2=VALUE=2';
-    const cf = new CloudFunction({ name, runtime, parent, envVars });
-    expect(cf.request.name).equal(`${parent}/functions/${name}`);
-    expect(cf.request.runtime).equal(runtime);
-    expect(cf.request.httpsTrigger).not.to.be.null;
-    expect(cf.request.environmentVariables?.KEY1).equal('VALUE=1');
-    expect(cf.request.environmentVariables?.KEY2).equal('VALUE=2');
-  });
-
-  it('creates a http function with envVarsFile', function () {
-    const envVarsFile = 'tests/env-var-files/test.good.yaml';
-    const cf = new CloudFunction({ name, runtime, parent, envVarsFile });
-    expect(cf.request.name).equal(`${parent}/functions/${name}`);
-    expect(cf.request.environmentVariables?.KEY1).equal('VALUE1');
-    expect(cf.request.environmentVariables?.KEY2).equal('VALUE2');
-    expect(cf.request.environmentVariables?.JSONKEY).equal('{"bar":"baz"}');
-  });
-
-  it('throws an error with bad envVarsFile', function () {
-    const envVarsFile = 'tests/env-var-files/test.bad.yaml';
-    expect(function () {
-      new CloudFunction({ name, runtime, parent, envVarsFile });
-    }).to.throw(
-      'env_vars_file yaml must contain only key/value pair of strings. Error parsing key KEY2 of type string with value VALUE2,VALUE3 of type object',
-    );
-  });
-
-  it('throws an error with nonexistent envVarsFile', function () {
-    const envVarsFile = 'tests/env-var-files/test.nonexistent.yaml';
-    expect(function () {
-      new CloudFunction({ name, runtime, parent, envVarsFile });
-    }).to.throw(
-      "ENOENT: no such file or directory, open 'tests/env-var-files/test.nonexistent.yaml",
     );
   });
 

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -97,16 +97,20 @@ describe('CloudFunction', function () {
     expect(cf.request.environmentVariables?.KEY3).equal('VALUE3');
   });
 
-  it('creates a http function with some quoted and some unquoted envVars', function () {
-    const obj = { foo: 'bar', baz: 'foo' };
-    const envVars = `KEY1="${JSON.stringify(obj)}",KEY2=VALUE2,KEY3=VALUE3`;
-    const cf = new CloudFunction({ name, runtime, parent, envVars });
+  it('creates a http function with custom delimiter', function () {
+    const envVars = `KEY1=VALUE1|KEY2=VALUE2|KEY3=VALUE3`;
+    const envVarsDelimiter = '|';
+    const cf = new CloudFunction({
+      name,
+      runtime,
+      parent,
+      envVars,
+      envVarsDelimiter,
+    });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
-    expect(
-      JSON.parse(cf.request.environmentVariables?.KEY1 || '{}'),
-    ).deep.equals(obj);
+    expect(cf.request.environmentVariables?.KEY1).equals('VALUE1');
     expect(cf.request.environmentVariables?.KEY2).equal('VALUE2');
     expect(cf.request.environmentVariables?.KEY3).equal('VALUE3');
   });

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -97,6 +97,17 @@ describe('CloudFunction', function () {
     expect(cf.request.environmentVariables?.KEY3).equal('VALUE3');
   });
 
+  it('creates a http function with quoted envVars', function () {
+    const envVars = 'KEY1="VALUE1.1,VALUE1.2",KEY2=VALUE2,KEY3=VALUE3';
+    const cf = new CloudFunction({ name, runtime, parent, envVars });
+    expect(cf.request.name).equal(`${parent}/functions/${name}`);
+    expect(cf.request.runtime).equal(runtime);
+    expect(cf.request.httpsTrigger).not.to.be.null;
+    expect(cf.request.environmentVariables?.KEY1).equal('VALUE1.1,VALUE1.2');
+    expect(cf.request.environmentVariables?.KEY2).equal('VALUE2');
+    expect(cf.request.environmentVariables?.KEY3).equal('VALUE3');
+  });
+
   it('throws an error with bad envVars', function () {
     const envVars = 'KEY1,VALUE1';
     expect(function () {

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -62,38 +62,50 @@ describe('Parse KV pairs', function () {
       {
         name: 'parse single unquoted envVar',
         input: 'KEY1=VALUE1',
+        delimiter: ',',
         output: { KEY1: 'VALUE1' },
       },
       {
         name: 'parse single quoted envVar',
         input: 'KEY1="VALUE1"',
-        output: { KEY1: 'VALUE1' },
+        delimiter: ',',
+        output: { KEY1: '"VALUE1"' },
       },
       {
         name: 'parse multiple unquoted envVars',
         input: 'KEY1=VALUE1,KEY2=VALUE2',
+        delimiter: ',',
         output: { KEY1: 'VALUE1', KEY2: 'VALUE2' },
       },
       {
         name: 'parse multiple quoted envVars',
         input: 'KEY1="VALUE1",KEY2="VALUE2"',
-        output: { KEY1: 'VALUE1', KEY2: 'VALUE2' },
+        delimiter: ',',
+        output: { KEY1: '"VALUE1"', KEY2: '"VALUE2"' },
       },
       {
         name: 'parse mix of quoted and unquoted envVars',
         input: 'KEY1=VALUE1,KEY2="VALUE2"',
-        output: { KEY1: 'VALUE1', KEY2: 'VALUE2' },
+        delimiter: ',',
+        output: { KEY1: 'VALUE1', KEY2: '"VALUE2"' },
       },
       {
         name: 'parse envVars with multiple = characters',
         input: 'KEY1=VALUE=1,KEY2=VALUE=2',
+        delimiter: ',',
         output: { KEY1: 'VALUE=1', KEY2: 'VALUE=2' },
+      },
+      {
+        name: 'parse envVars that are quoted JSON',
+        input: 'KEY1={"foo":"v1,v2","bar":"v3"}|KEY2=FOO',
+        delimiter: '|',
+        output: { KEY1: '{"foo":"v1,v2","bar":"v3"}', KEY2: 'FOO' },
       },
     ];
 
     positiveParsingTests.forEach((test) => {
       it(test.name, () => {
-        expect(parseKVPairs(test.input)).to.deep.equal(test.output);
+        expect(parseKVPairs(test.input, test.delimiter)).to.deep.equal(test.output);
       });
     });
   });
@@ -102,12 +114,14 @@ describe('Parse KV pairs', function () {
       {
         name: 'throws an error if envVars is malformed',
         input: 'KEY1,VALUE1',
+        delimiter: ',',
         error:
           'The expected data format should be "KEY1=VALUE1", got "KEY1" while parsing "KEY1,VALUE1"',
       },
       {
         name: 'throws an error if envVars are not quoted correctly',
         input: 'KEY1="VALUE1.1,VALUE1.2,KEY2="VALUE2"',
+        delimiter: ',',
         error:
           'The expected data format should be "KEY1=VALUE1", got "VALUE1.2" while parsing "KEY1="VALUE1.1,VALUE1.2,KEY2="VALUE2""',
       },
@@ -115,7 +129,7 @@ describe('Parse KV pairs', function () {
     negativeParsingTests.forEach((test) => {
       it(test.name, () => {
         expect(function () {
-          parseKVPairs(test.input);
+          parseKVPairs(test.input, test.delimiter);
         }).to.throw(test.error);
       });
     });

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -101,11 +101,20 @@ describe('Parse KV pairs', function () {
         delimiter: '|',
         output: { KEY1: '{"foo":"v1,v2","bar":"v3"}', KEY2: 'FOO' },
       },
+      {
+        name: 'parse envVars that are delimited by newline',
+        input: `KEY1={"foo":"v1,v2","bar":"v3"}
+KEY2=FOO`,
+        delimiter: '\n',
+        output: { KEY1: '{"foo":"v1,v2","bar":"v3"}', KEY2: 'FOO' },
+      },
     ];
 
     positiveParsingTests.forEach((test) => {
       it(test.name, () => {
-        expect(parseKVPairs(test.input, test.delimiter)).to.deep.equal(test.output);
+        expect(parseKVPairs(test.input, test.delimiter)).to.deep.equal(
+          test.output,
+        );
       });
     });
   });

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -57,51 +57,68 @@ describe('Zip', function () {
 });
 
 describe('Parse KV pairs', function () {
-  it('parse single unquoted envVar', async function () {
-    const envVar = 'KEY1=VALUE1';
-    const pairs = parseKVPairs(envVar);
-    expect(pairs).deep.equal({ KEY1: 'VALUE1' });
+  describe('Positive parsing tests', () => {
+    const positiveParsingTests = [
+      {
+        name: 'parse single unquoted envVar',
+        input: 'KEY1=VALUE1',
+        output: { KEY1: 'VALUE1' },
+      },
+      {
+        name: 'parse single quoted envVar',
+        input: 'KEY1="VALUE1"',
+        output: { KEY1: 'VALUE1' },
+      },
+      {
+        name: 'parse multiple unquoted envVars',
+        input: 'KEY1=VALUE1,KEY2=VALUE2',
+        output: { KEY1: 'VALUE1', KEY2: 'VALUE2' },
+      },
+      {
+        name: 'parse multiple quoted envVars',
+        input: 'KEY1="VALUE1",KEY2="VALUE2"',
+        output: { KEY1: 'VALUE1', KEY2: 'VALUE2' },
+      },
+      {
+        name: 'parse mix of quoted and unquoted envVars',
+        input: 'KEY1=VALUE1,KEY2="VALUE2"',
+        output: { KEY1: 'VALUE1', KEY2: 'VALUE2' },
+      },
+      {
+        name: 'parse envVars with multiple = characters',
+        input: 'KEY1=VALUE=1,KEY2=VALUE=2',
+        output: { KEY1: 'VALUE=1', KEY2: 'VALUE=2' },
+      },
+    ];
+
+    positiveParsingTests.forEach((test) => {
+      it(test.name, () => {
+        expect(parseKVPairs(test.input)).to.deep.equal(test.output);
+      });
+    });
   });
-  it('parse single quoted envVar', async function () {
-    const envVar = 'KEY1="VALUE1"';
-    const pairs = parseKVPairs(envVar);
-    expect(pairs).deep.equal({ KEY1: 'VALUE1' });
-  });
-  it('parse multiple unquoted envVars', async function () {
-    const envVars = 'KEY1=VALUE1,KEY2=VALUE2';
-    const pairs = parseKVPairs(envVars);
-    expect(pairs).deep.equal({ KEY1: 'VALUE1', KEY2: 'VALUE2' });
-  });
-  it('parse multiple quoted envVars', async function () {
-    const envVars = 'KEY1="VALUE1",KEY2="VALUE2"';
-    const pairs = parseKVPairs(envVars);
-    expect(pairs).deep.equal({ KEY1: 'VALUE1', KEY2: 'VALUE2' });
-  });
-  it('parse mix of quoted and unquoted envVars', async function () {
-    const envVars = 'KEY1=VALUE1,KEY2="VALUE2"';
-    const pairs = parseKVPairs(envVars);
-    expect(pairs).deep.equal({ KEY1: 'VALUE1', KEY2: 'VALUE2' });
-  });
-  it('parse envVars with multiple = characters', async function () {
-    const envVars = 'KEY1=VALUE=1,KEY2=VALUE=2';
-    const pairs = parseKVPairs(envVars);
-    expect(pairs).deep.equal({ KEY1: 'VALUE=1', KEY2: 'VALUE=2' });
-  });
-  it('throws an error if envVars is malformed', async function () {
-    const envVars = 'KEY1,VALUE1';
-    expect(function () {
-      parseKVPairs(envVars);
-    }).to.throw(
-      'The expected data format should be "KEY1=VALUE1", got "KEY1" while parsing "KEY1,VALUE1"',
-    );
-  });
-  it('throws an error if envVars are not quoted correctly', async function () {
-    const envVars = 'KEY1="VALUE1.1,VALUE1.2,KEY2="VALUE2"';
-    expect(function () {
-      parseKVPairs(envVars);
-    }).to.throw(
-      `The expected data format should be "KEY1=VALUE1", got "VALUE1.2" while parsing "KEY1="VALUE1.1,VALUE1.2,KEY2="VALUE2""`,
-    );
+  describe('Negative parsing tests', () => {
+    const negativeParsingTests = [
+      {
+        name: 'throws an error if envVars is malformed',
+        input: 'KEY1,VALUE1',
+        error:
+          'The expected data format should be "KEY1=VALUE1", got "KEY1" while parsing "KEY1,VALUE1"',
+      },
+      {
+        name: 'throws an error if envVars are not quoted correctly',
+        input: 'KEY1="VALUE1.1,VALUE1.2,KEY2="VALUE2"',
+        error:
+          'The expected data format should be "KEY1=VALUE1", got "VALUE1.2" while parsing "KEY1="VALUE1.1,VALUE1.2,KEY2="VALUE2""',
+      },
+    ];
+    negativeParsingTests.forEach((test) => {
+      it(test.name, () => {
+        expect(function () {
+          parseKVPairs(test.input);
+        }).to.throw(test.error);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Adds support for custom delimiters for environment variables.

Currently we are naively just splitting the string on `,` via `str.split(",")`, which also splits commas that might be inside quotes.

For example
```
env_vars: KEY1="val1.1,val1.2",KEY2=val2
```
gets split as 
```
[ 'KEY1="val1.1', 'val1.2"', 'KEY2=val2' ]
```


This PR adds the option to set a custom delimiter via the `env_vars_delimiter` key.

Added a test cases for a common example of where this would be useful - passing JSON stringified objects as environmental variables.