### PR TITLE
feat: Add secret option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ steps:
 
 - `deploy_timeout`: (Optional) The function deployment timeout in seconds. Defaults to 300.
 
+- `secrets`: (Optional) List of key-value pairs to set secrets as environment variables or mounted files, delimited by line breaks. Format of expression can be found [here](https://cloud.google.com/sdk/gcloud/reference/beta/functions/deploy#--set-secrets).
+
 ## Allow unauthenticated requests
 
 A Cloud Functions product recommendation is that CI/CD systems not set or change

--- a/action.yaml
+++ b/action.yaml
@@ -131,6 +131,12 @@ inputs:
       The function deployment timeout in seconds.
     required: false
 
+  secrets:
+    description: |-
+      List of key-value pairs to set secrets as environment variables or mounted files, delimited by line breaks.
+      The form of each line must be ENV_VAR_OR_SECRET_PATH=SECRET_REF.
+    required: false
+
 outputs:
   url:
     description: The URL of your Cloud Function. Only available with HTTP Trigger.

--- a/src/cloudFunction.ts
+++ b/src/cloudFunction.ts
@@ -269,13 +269,22 @@ export class CloudFunction {
 
       if (secretPathPattern.test(secretKey)) {
         const { mountPath, secretPath } = this.parseSecretPath(secretKey);
-        const volume = {
-          mountPath,
-          projectId,
-          secret,
-          versions: [{ path: secretPath, version }],
-        };
-        volumes.push(volume);
+        const volume = volumes.find(
+          (v) =>
+            v.mountPath === mountPath &&
+            v.projectId == projectId &&
+            v.secret === secret,
+        );
+        if (!volume) {
+          volumes.push({
+            mountPath,
+            projectId,
+            secret,
+            versions: [{ path: secretPath, version }],
+          });
+        } else {
+          volume.versions?.push({ path: secretPath, version });
+        }
       } else {
         const envVar = { key: secretKey, projectId, secret, version };
         envVars.push(envVar);

--- a/src/cloudFunctionClient.ts
+++ b/src/cloudFunctionClient.ts
@@ -256,6 +256,8 @@ export class CloudFunctionClient {
         'eventTrigger.resource',
         'eventTrigger.service',
         'labels',
+        'secretEnvironmentVariables',
+        'secretVolumes',
       ];
       const updateFunctionRequest: cloudfunctions_v1.Params$Resource$Projects$Locations$Functions$Patch =
         {

--- a/src/cloudFunctionClient.ts
+++ b/src/cloudFunctionClient.ts
@@ -60,6 +60,7 @@ export class CloudFunctionClient {
   private gcf = google.cloudfunctions('v1');
   readonly auth: GoogleAuth;
   readonly parent: string;
+  readonly projectId: string;
   authClient:
     | JWT
     | Compute
@@ -106,6 +107,7 @@ export class CloudFunctionClient {
       throw new Error('No project Id found. Set project Id in this action.');
     }
 
+    this.projectId = projectId || '';
     this.parent = `projects/${projectId}/locations/${region}`;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ async function run(): Promise<void> {
     const eventTriggerService = core.getInput('event_trigger_service');
     const deployTimeout = core.getInput('deploy_timeout');
     const labels = core.getInput('labels');
+    const secrets = core.getInput('secrets');
 
     // Create Cloud Functions client
     const client = new CloudFunctionClient(region, { projectId, credentials });
@@ -69,6 +70,7 @@ async function run(): Promise<void> {
       ingressSettings,
       serviceAccountEmail,
       labels,
+      secrets,
     });
 
     // Deploy function

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ async function run(): Promise<void> {
     const newFunc = new CloudFunction({
       name: name,
       parent: client.parent,
+      projectId: client.projectId,
       sourceDir,
       runtime,
       availableMemoryMb: +availableMemoryMb,

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -6,10 +6,11 @@ import { CloudFunction } from '../src/cloudFunction';
 const name = 'fooFunction';
 const runtime = 'fooRunTime';
 const parent = 'projects/fooProject/locations/fooRegion';
+const projectId = 'fooProject';
 
 describe('CloudFunction', function () {
   it('creates a http function', function () {
-    const cf = new CloudFunction({ name, runtime, parent });
+    const cf = new CloudFunction({ name, runtime, parent, projectId });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -18,7 +19,7 @@ describe('CloudFunction', function () {
 
   it('creates a http function with one envVar', function () {
     const envVars = 'KEY1=VALUE1';
-    const cf = new CloudFunction({ name, runtime, parent, envVars });
+    const cf = new CloudFunction({ name, runtime, parent, projectId, envVars });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -27,7 +28,7 @@ describe('CloudFunction', function () {
 
   it('creates an http function with one label', function () {
     const labels = 'label1=value1';
-    const cf = new CloudFunction({ name, runtime, parent, labels });
+    const cf = new CloudFunction({ name, runtime, parent, projectId, labels });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -36,7 +37,7 @@ describe('CloudFunction', function () {
 
   it('creates an http function with two labels', function () {
     const labels = 'label1=value1,label2=value2';
-    const cf = new CloudFunction({ name, runtime, parent, labels });
+    const cf = new CloudFunction({ name, runtime, parent, projectId, labels });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -67,6 +68,7 @@ describe('CloudFunction', function () {
       availableMemoryMb: 512,
       labels: labels,
       secrets: secrets,
+      projectId: projectId,
     };
     const cf = new CloudFunction(funcOptions);
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
@@ -100,7 +102,7 @@ describe('CloudFunction', function () {
 
   it('creates a http function with three envVars', function () {
     const envVars = 'KEY1=VALUE1,KEY2=VALUE2,KEY3=VALUE3';
-    const cf = new CloudFunction({ name, runtime, parent, envVars });
+    const cf = new CloudFunction({ name, runtime, parent, projectId, envVars });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -112,7 +114,7 @@ describe('CloudFunction', function () {
   it('throws an error with bad envVars', function () {
     const envVars = 'KEY1,VALUE1';
     expect(function () {
-      new CloudFunction({ name, runtime, parent, envVars });
+      new CloudFunction({ name, runtime, parent, projectId, envVars });
     }).to.throw(
       'The expected data format should be "KEY1=VALUE1", got "KEY1" while parsing "KEY1,VALUE1"',
     );
@@ -121,7 +123,7 @@ describe('CloudFunction', function () {
   it('throws an error with bad labels', function () {
     const envVars = 'label1=value1,label2';
     expect(function () {
-      new CloudFunction({ name, runtime, parent, envVars });
+      new CloudFunction({ name, runtime, parent, projectId, envVars });
     }).to.throw(
       'The expected data format should be "KEY1=VALUE1", got "label2" while parsing "label1=value1,label2"',
     );
@@ -129,7 +131,7 @@ describe('CloudFunction', function () {
 
   it('creates a http function with two envVars containing equals character', function () {
     const envVars = 'KEY1=VALUE=1,KEY2=VALUE=2';
-    const cf = new CloudFunction({ name, runtime, parent, envVars });
+    const cf = new CloudFunction({ name, runtime, parent, projectId, envVars });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -139,7 +141,13 @@ describe('CloudFunction', function () {
 
   it('creates a http function with envVarsFile', function () {
     const envVarsFile = 'tests/env-var-files/test.good.yaml';
-    const cf = new CloudFunction({ name, runtime, parent, envVarsFile });
+    const cf = new CloudFunction({
+      name,
+      runtime,
+      parent,
+      projectId,
+      envVarsFile,
+    });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.environmentVariables?.KEY1).equal('VALUE1');
     expect(cf.request.environmentVariables?.KEY2).equal('VALUE2');
@@ -149,7 +157,7 @@ describe('CloudFunction', function () {
   it('throws an error with bad envVarsFile', function () {
     const envVarsFile = 'tests/env-var-files/test.bad.yaml';
     expect(function () {
-      new CloudFunction({ name, runtime, parent, envVarsFile });
+      new CloudFunction({ name, runtime, parent, projectId, envVarsFile });
     }).to.throw(
       'env_vars_file yaml must contain only key/value pair of strings. Error parsing key KEY2 of type string with value VALUE2,VALUE3 of type object',
     );
@@ -158,7 +166,7 @@ describe('CloudFunction', function () {
   it('throws an error with nonexistent envVarsFile', function () {
     const envVarsFile = 'tests/env-var-files/test.nonexistent.yaml';
     expect(function () {
-      new CloudFunction({ name, runtime, parent, envVarsFile });
+      new CloudFunction({ name, runtime, parent, projectId, envVarsFile });
     }).to.throw(
       "ENOENT: no such file or directory, open 'tests/env-var-files/test.nonexistent.yaml",
     );
@@ -171,6 +179,7 @@ describe('CloudFunction', function () {
       name,
       runtime,
       parent,
+      projectId,
       envVarsFile,
       envVars,
     });
@@ -189,6 +198,7 @@ describe('CloudFunction', function () {
       name,
       runtime,
       parent,
+      projectId,
       envVarsFile,
       envVars,
     });
@@ -200,7 +210,7 @@ describe('CloudFunction', function () {
 
   it('creates an http function with one secret environment variable', function () {
     const secrets = 'ENV_VAR1=SECRET1:1';
-    const cf = new CloudFunction({ name, runtime, parent, secrets });
+    const cf = new CloudFunction({ name, runtime, parent, projectId, secrets });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -212,7 +222,7 @@ describe('CloudFunction', function () {
   it('creates an http function with one secret volume', function () {
     const secrets =
       '/etc/secrets/PATH1=projects/PROJECT1/secrets/SECRET1:latest';
-    const cf = new CloudFunction({ name, runtime, parent, secrets });
+    const cf = new CloudFunction({ name, runtime, parent, projectId, secrets });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -226,7 +236,7 @@ describe('CloudFunction', function () {
   it('creates an http function with one secret volume', function () {
     const secrets =
       '/MOUNT_PATH1:/SECRET_PATH1=projects/PROJECT1/secrets/SECRET1/versions/1';
-    const cf = new CloudFunction({ name, runtime, parent, secrets });
+    const cf = new CloudFunction({ name, runtime, parent, projectId, secrets });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -244,7 +254,7 @@ describe('CloudFunction', function () {
       'ENV_VAR1=SECRET1:1\n' +
       '/etc/secrets/PATH2=projects/PROJECT2/secrets/SECRET2:latest\n' +
       '/MOUNT_PATH3:/SECRET_PATH3=projects/PROJECT3/secrets/SECRET3/versions/3';
-    const cf = new CloudFunction({ name, runtime, parent, secrets });
+    const cf = new CloudFunction({ name, runtime, parent, projectId, secrets });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
     expect(cf.request.httpsTrigger).not.to.be.null;
@@ -268,7 +278,7 @@ describe('CloudFunction', function () {
   it('throws an error with bad secrets', function () {
     const secrets = 'ENV_VAR1=SECRET1:latest\nSECRET2';
     expect(function () {
-      new CloudFunction({ name, runtime, parent, secrets });
+      new CloudFunction({ name, runtime, parent, projectId, secrets });
     }).to.throw(
       'The expected data format should be "ENV_VAR=SECRET_REF" or "/SECRET_PATH=SECRET_REF", got "SECRET2" while parsing "ENV_VAR1=SECRET1:latest\nSECRET2"',
     );
@@ -279,7 +289,7 @@ describe('CloudFunction', function () {
       '/etc/secrets/PATH2=projects/PROJECT2/secrets/SECRET2:latest\n' +
       '/MOUNT_PATH3:/SECRET_PATH3=SECRET3';
     expect(function () {
-      new CloudFunction({ name, runtime, parent, secrets });
+      new CloudFunction({ name, runtime, parent, projectId, secrets });
     }).to.throw(
       'The expected secrets value format must match the pattern "SECRET:VERSION", "projects/PROJECT/secrets/SECRET:VERSION" or "projects/PROJECT/secrets/SECRET/versions/VERSION", got "SECRET3"',
     );
@@ -292,6 +302,7 @@ describe('CloudFunction', function () {
       name,
       runtime,
       parent,
+      projectId,
       eventTriggerType,
       eventTriggerResource,
     });
@@ -313,6 +324,7 @@ describe('CloudFunction', function () {
       runtime,
       envVars,
       parent,
+      projectId,
       eventTriggerType,
       eventTriggerResource,
     });
@@ -333,6 +345,7 @@ describe('CloudFunction', function () {
         name,
         runtime,
         parent,
+        projectId,
         eventTriggerResource,
       });
     }).to.throw(

--- a/tests/cloudFunction.test.ts
+++ b/tests/cloudFunction.test.ts
@@ -253,7 +253,8 @@ describe('CloudFunction', function () {
     const secrets =
       'ENV_VAR1=SECRET1:1\n' +
       '/etc/secrets/PATH2=projects/PROJECT2/secrets/SECRET2:latest\n' +
-      '/MOUNT_PATH3:/SECRET_PATH3=projects/PROJECT3/secrets/SECRET3/versions/3';
+      '/MOUNT_PATH3:/SECRET_PATH3=projects/PROJECT3/secrets/SECRET3/versions/3\n' +
+      '/etc/secrets/SECRET_PATH4=projects/PROJECT2/secrets/SECRET2/versions/4';
     const cf = new CloudFunction({ name, runtime, parent, projectId, secrets });
     expect(cf.request.name).equal(`${parent}/functions/${name}`);
     expect(cf.request.runtime).equal(runtime);
@@ -266,6 +267,10 @@ describe('CloudFunction', function () {
     expect(cf.request.secretVolumes?.[0].secret).equal('SECRET2');
     expect(cf.request.secretVolumes?.[0].versions?.[0].path).equal('/PATH2');
     expect(cf.request.secretVolumes?.[0].versions?.[0].version).equal('latest');
+    expect(cf.request.secretVolumes?.[0].versions?.[1].path).equal(
+      '/SECRET_PATH4',
+    );
+    expect(cf.request.secretVolumes?.[0].versions?.[1].version).equal('4');
     expect(cf.request.secretVolumes?.[1].mountPath).equal('/MOUNT_PATH3');
     expect(cf.request.secretVolumes?.[1].projectId).equal('PROJECT3');
     expect(cf.request.secretVolumes?.[1].secret).equal('SECRET3');

--- a/tests/cloudFunctionClient.test.ts
+++ b/tests/cloudFunctionClient.test.ts
@@ -55,6 +55,8 @@ describe('CloudFunction', function () {
       sourceDir: testNodeFuncDir,
       runtime: 'nodejs10',
       envVars: 'KEY1=VALUE1,KEY2=VALUE2',
+      secrets: `ENV_VAR1=DEPLOY_CF_SECRET:1
+/MOUNT_PATH2:/SECRET_PATH2=projects/${project}/secrets/DEPLOY_CF_SECRET:latest`,
       entryPoint: 'helloWorld',
       availableMemoryMb: 512,
     });
@@ -84,6 +86,8 @@ describe('CloudFunction', function () {
       sourceDir: testNodeFuncDir,
       runtime: 'nodejs10',
       envVars: 'KEY1=VALUE1,KEY2=VALUE2',
+      secrets: `ENV_VAR1=DEPLOY_CF_SECRET:1
+  /MOUNT_PATH2:/SECRET_PATH2=projects/${project}/secrets/DEPLOY_CF_SECRET:latest`,
       entryPoint: 'helloWorld',
       eventTriggerType: eventTriggerType,
       eventTriggerResource: pubsubTopicFQN,
@@ -116,6 +120,8 @@ describe('CloudFunction', function () {
       sourceDir: testNodeFuncDir,
       runtime: 'nodejs10',
       envVars: 'KEY1=VALUE1,KEY2=VALUE2',
+      secrets: `ENV_VAR1=DEPLOY_CF_SECRET:1
+/MOUNT_PATH2:/SECRET_PATH2=projects/${project}/secrets/DEPLOY_CF_SECRET:latest`,
       entryPoint: 'helloWorld',
     });
     await client.deploy(firstHttpFunc);
@@ -125,6 +131,10 @@ describe('CloudFunction', function () {
       sourceDir: testNodeFuncDir,
       runtime: 'nodejs10',
       envVars: 'KEY1=VALUE1,KEY2=VALUE2,KEY3=VALUE3',
+      secrets: `ENV_VAR1=DEPLOY_CF_SECRET:1
+/MOUNT_PATH2:/SECRET_PATH2=projects/${project}/secrets/DEPLOY_CF_SECRET:latest
+ENV_VAR3=projects/${project}/secrets/DEPLOY_CF_SECRET:latest
+/etc/secrets/SECRET_PATH4=projects/${project}/secrets/DEPLOY_CF_SECRET/versions/1`,
       entryPoint: 'helloWorld',
     });
     const result = await client.deploy(updatedHttpFunc);

--- a/tests/cloudFunctionClient.test.ts
+++ b/tests/cloudFunctionClient.test.ts
@@ -59,6 +59,7 @@ describe('CloudFunction', function () {
 /MOUNT_PATH2:/SECRET_PATH2=projects/${project}/secrets/DEPLOY_CF_SECRET:latest`,
       entryPoint: 'helloWorld',
       availableMemoryMb: 512,
+      projectId: client.projectId,
     });
     const result = await client.deploy(newHttpFunc);
     // expect function to be deployed without error
@@ -91,6 +92,7 @@ describe('CloudFunction', function () {
       entryPoint: 'helloWorld',
       eventTriggerType: eventTriggerType,
       eventTriggerResource: pubsubTopicFQN,
+      projectId: client.projectId,
     });
 
     const result = await client.deploy(newEventFunc);
@@ -123,6 +125,7 @@ describe('CloudFunction', function () {
       secrets: `ENV_VAR1=DEPLOY_CF_SECRET:1
 /MOUNT_PATH2:/SECRET_PATH2=projects/${project}/secrets/DEPLOY_CF_SECRET:latest`,
       entryPoint: 'helloWorld',
+      projectId: client.projectId,
     });
     await client.deploy(firstHttpFunc);
     const updatedHttpFunc = new CloudFunction({
@@ -136,6 +139,7 @@ describe('CloudFunction', function () {
 ENV_VAR3=projects/${project}/secrets/DEPLOY_CF_SECRET:latest
 /etc/secrets/SECRET_PATH4=projects/${project}/secrets/DEPLOY_CF_SECRET/versions/1`,
       entryPoint: 'helloWorld',
+      projectId: client.projectId,
     });
     const result = await client.deploy(updatedHttpFunc);
     // expect function to be deployed without error
@@ -167,6 +171,7 @@ ENV_VAR3=projects/${project}/secrets/DEPLOY_CF_SECRET:latest
       runtime: 'nodejs10',
       envVarsFile: 'tests/env-var-files/test.good.yaml',
       entryPoint: 'helloWorld',
+      projectId: client.projectId,
     });
     const result = await client.deploy(newHttpFunc);
     // expect function to be deployed without error


### PR DESCRIPTION
This PR adds `secret` option to support for passing secrets as environment variables and mounting secrets as volumes.

The format of input value is similer to [gcloud CLI](https://cloud.google.com/sdk/gcloud/reference/beta/functions/deploy#--set-secrets) but delimiter is changed from comma `,` to line break `\n` for ease of use on yaml.
It could be changed if there are any other suggestions.

Resolves #187 