### PR TITLE
feat: fail the GitHub Action run if the Cloud Function is not ACTIVE

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -212,6 +212,16 @@ async function run(): Promise<void> {
         };
       })(),
     });
+
+    if (resp.status !== 'ACTIVE') {
+      throw new Error(
+        `Cloud Function deployment finished, but the function not in the ` +
+          `"ACTIVE" status. The current status is "${resp.status}", which ` +
+          `could indicate a failed deployment. Check the Cloud Function ` +
+          `logs for more information.`,
+      );
+    }
+
     if (resp.httpsTrigger?.url) {
       setOutput('url', resp.httpsTrigger.url);
     } else {


### PR DESCRIPTION
There are situations in which the polling operation will complete, but the Cloud Function status is "UNKNOWN" or other values. This usually happens when the deploy succeeds, but the instance immediately dies on boot. In these cases, users need to go look at Cloud Logging to inspect why the deployment succeeded but the instance booting failed.

By checking if the status is ACTIVE, we can ensure that the GitHub Action only "succeeds" if the function fully deploys.

Fixes #71 