### PR TITLE
Ability to use secret without any project

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -160,7 +160,7 @@ async function run(): Promise<void> {
     const secretEnvironmentVariables: SecretEnvVar[] = [];
     if (secretEnvVars) {
       for (const [key, value] of Object.entries(secretEnvVars)) {
-        const secretRef = new SecretName(value);
+        const secretRef = new SecretName(value, projectID);
         secretEnvironmentVariables.push({
           key: key,
           projectId: secretRef.project,
@@ -177,7 +177,7 @@ async function run(): Promise<void> {
         const mountPath = posix.dirname(key);
         const pth = posix.basename(key);
 
-        const secretRef = new SecretName(value);
+        const secretRef = new SecretName(value, projectID);
         secretVolumes.push({
           mountPath: mountPath,
           projectId: secretRef.project,

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -18,6 +18,7 @@
  * Parses a string into a Google Secret Manager reference.
  *
  * @param s String reference to parse
+ * @param projectId String GCP project Id based on credentials file
  * @returns Reference
  */
 export class SecretName {
@@ -26,7 +27,7 @@ export class SecretName {
   readonly name: string;
   readonly version: string;
 
-  constructor(s: string | null | undefined) {
+  constructor(s: string | null | undefined, projectId: string) {
     s = (s || '').trim();
     if (!s) {
       throw new Error(`Missing secret name`);
@@ -59,6 +60,13 @@ export class SecretName {
       case 2: {
         this.project = refParts[0];
         this.name = refParts[1];
+        this.version = 'latest';
+        break;
+      }
+      // <s>
+      case 1: {
+        this.project = projectId;
+        this.name = refParts[0];
         this.version = 'latest';
         break;
       }


### PR DESCRIPTION
Hello,

As per the bug issue I just opened : https://github.com/google-github-actions/deploy-cloud-functions/issues/294
I propose this implementation to give ability to load a secret without project id, based on the one calculated in the main.

However, as per the current management of the secret value, it's not possible to specify a `version` without specifying the `project`

Thanks