### PR TITLE
docs: fix relative link syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 # deploy-cloud-functions
 
-This action deploys your function source code to [Cloud Functions](cloud-functions) and makes the URL
+This action deploys your function source code to [Cloud Functions][cloud-functions] and makes the URL
 available to later build steps via outputs.
 
 **This GitHub Action is _declarative_, meaning it will overwrite any values on


### PR DESCRIPTION
Unlike [inline links](https://github.github.com/gfm/#inline-link), [reference links](https://github.github.com/gfm/#reference-link) require that the link text be followed by a string (a link label that matches a link reference definition elsewhere in the document) that is enclosed in *brackets*, not in parenthesis.

Because this link text was followed a string enclosed in parenthesis, it was rendered as if that string is a relative URI, resulting in a valid URI for a nonexistent resource.

Signed-off-by: Phil Mocek <pmocek-github@mocek.org>

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
