### PR TITLE
Add 2nd gen function support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ jobs:
 
 - `runtime`: (Required) Runtime to use for the function. Possible options documented [here][runtimes].
 
+- `gen2`: (Optional) Create a gen2 function. This field expects 1 (enabled) or 0 (disabled) as the value.
+
 - `entry_point`: (Optional) Name of a function (as defined in source code) that will be executed. Defaults to the resource name suffix, if not specified.
 
 - `memory_mb`: (Optional) The amount of memory in MB available for a function. Defaults to '256' (256 MB). The value must be the number of megabytes _without_ the unit suffix.

--- a/src/client.ts
+++ b/src/client.ts
@@ -96,6 +96,7 @@ export type CloudFunction = {
   timeout?: string;
   vpcConnector?: string;
   vpcConnectorEgressSettings?: string;
+  gen2?: boolean;
 
   // oneof
   sourceArchiveUrl?: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,6 +69,7 @@ async function run(): Promise<void> {
     const eventTriggerRetry = getBooleanInput('event_trigger_retry');
     const deployTimeout = presence(getInput('deploy_timeout'));
     const labels = parseKVString(getInput('labels'));
+    const gen2 = getInput('gen2') === '1';
 
     const buildEnvVars = presence(getInput('build_environment_variables'));
     const buildEnvVarsFile = presence(getInput('build_environment_variables_file'));
@@ -208,6 +209,10 @@ async function run(): Promise<void> {
       vpcConnector: vpcConnector,
       vpcConnectorEgressSettings: vpcConnectorEgressSettings,
     };
+
+    if (gen2) {
+      cf.gen2 = gen2;
+    }
 
     if (eventTriggerType && eventTriggerResource) {
       // Set event trigger properties.


### PR DESCRIPTION
As discussed in [https://github.com/google-github-actions/deploy-cloud-functions/issues/304](https://github.com/google-github-actions/deploy-cloud-functions/issues/304), it would be great to have gen2 functions support through this GitHub action without needing any further action rather than just specifying through an input value if we want to use or not second gen functions.

There are many advantages in favor of using 2nd gen functions, so I believe this is something most of us as devs will need.

This PR is adding a new gen2 input that will read the gen2 value (1 or 0) and add it to the request when deploying a cloud function.

The README file was updated having this new input field on the list of available inputs.