### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
 
 - `region`: (Optional) [Region](https://cloud.google.com/functions/docs/locations) in which the function should be deployed. Defaults to `us-central1`.
 
-- `env_vars`: (Optional) List of key-value pairs to set as environment variables in the format: `KEY1=VALUE1,KEY2=VALUE2`. All existing environment variables will be removed, even if this parameter is not passed.
+- `env_vars`: (Optional) List of key-value pairs to set as environment variables in the format: `KEY1=VALUE1,KEY2=VALUE2`. All existing environment variables will be removed, even if this parameter is not passed. Keys or values that contain a separator must be escaped with a backslash (`\,`, `\\n`). All leading and trailing whitespace is trimmed.
 
 - `env_vars_file`: (Optional) Path to a local YAML file with definitions for all environment variables. An example env_vars_file can be found [here](tests/env-var-files/test.good.yaml). All existing environment variables will be removed, even if this parameter is not passed. If `env_vars` is also given, values in `env_vars` take precendence over these values.
 


### PR DESCRIPTION
## Why
Because when using a JSON env var it fails with a message that says:

```
google-github-actions/deploy-cloud-functions failed with: failed to parse KEY=VALUE pair ""my_key":"my_value"": missing "="
```

This was happening because an env var was a JSON string and commas were not escaped. Therefore when parsing the env vars it failed when reaching the second key of the JSON string.

## What
Adds a clarification to the "env_vars" parameter so that the user knows they need to escape their commas. The clarification was borrowed from the [source code of the function that parses the env vars](https://github.com/google-github-actions/actions-utils/blob/main/src/kv.ts#L43)

Signed-off-by: Juan Manuel Ramallo <juanmanuelramallo@hey.com>

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
