### PR TITLE
docs: corrected readme example for memory format

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ jobs:
 
 -   <a name="memory"></a><a href="#user-content-memory"><code>memory</code></a>: _(Optional)_ The amount of memory available for the function to use. Allowed values are
     of the format: <number><unit> with allowed units of "k", "M", "G", "Ki",
-    "Mi", "Gi" (e.g 128M, 10Mb, 1024Gib).
+    "Mi", "Gi" (e.g 128M, 10Mb, 1024Gi).
 
     For all generations, the default value is 256MB of memory.
 


### PR DESCRIPTION
Smallest update in history... memory format in readme showed an example as 1024Gib.

The b is not allowed in gcloud so have removed for accuracy.

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
